### PR TITLE
regex to username input added #31

### DIFF
--- a/formValidation/index.html
+++ b/formValidation/index.html
@@ -8,17 +8,17 @@
   </head>
   <body>
     <section class="overlay">
-      <h1>Sign Up</h1>
+			<h1>Sign Up</h1>
       <p>Create an account:</p>
       <form action="submission.html" method="GET">
-        <!--Add the minlength and maxlength attributes to the input fields-->
         <label for="username">Username:</label>
         <br>
-        <input id="username" name="username" type="text" minlength="3" maxlength="15" required>
+				<!--Add the pattern attribute to the input below-->
+				<input id="username" name="username" type="text" required minlength="3" maxlength="15" pattern="[a-zA-Z0-9]+">
         <br>
         <label for="pw">Password:</label>
         <br>
-        <input id="pw" name="pw" type="password" minlength="8" maxlength="15" required>
+				<input id="pw" name="pw" type="password" required minlength="8" maxlength="15">
         <br>
         <input type="submit" value="Submit">
       </form>


### PR DESCRIPTION
We added a pattern attribute and set it to: "[a-zA-Z0-9]+" in the first input element of username. Limit usernames to only letters and numbers (and not special characters like ! or @).